### PR TITLE
First step in updating to GWT 2.6.0-rc1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>net.ltgt.gwt.maven</groupId>
   <artifactId>gwt-maven-plugin</artifactId>
-  <version>1.0-SNAPSHOT</version>
+  <version>2.6.0-rc1-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>GWT Maven Plugin</name>
@@ -44,7 +44,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <gwt.version>2.5.1</gwt.version>
+    <gwt.version>2.6.0-rc1</gwt.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Fix for #11 - this gets the compile mojo to pass all integration tests and exposes new features, though still doesn't get `gwt:test` to work correctly. Current stack trace:

```
   [ERROR] Unexpected error while processing XML
java.lang.ClassCastException: org.apache.xerces.parsers.XIncludeAwareParserConfiguration cannot be cast to org.apache.xerces.xni.parser.XMLParserConfiguration
        at org.apache.xerces.parsers.SAXParser.<init>(Unknown Source)
        at org.apache.xerces.parsers.SAXParser.<init>(Unknown Source)
        at org.apache.xerces.jaxp.SAXParserImpl$JAXPSAXParser.<init>(Unknown Source)
        at org.apache.xerces.jaxp.SAXParserImpl.<init>(Unknown Source)
        at org.apache.xerces.jaxp.SAXParserFactoryImpl.newSAXParser(Unknown Source)
        at com.google.gwt.dev.util.xml.ReflectiveParser.createNewSaxParser(ReflectiveParser.java:65)
        at com.google.gwt.dev.util.xml.ReflectiveParser.access$000(ReflectiveParser.java:46)
        at com.google.gwt.dev.util.xml.ReflectiveParser$Impl.parse(ReflectiveParser.java:343)
        at com.google.gwt.dev.util.xml.ReflectiveParser$Impl.access$200(ReflectiveParser.java:68)
        at com.google.gwt.dev.util.xml.ReflectiveParser.parse(ReflectiveParser.java:418)
        at com.google.gwt.dev.cfg.ModuleDefLoader.nestedLoad(ModuleDefLoader.java:333)
        at com.google.gwt.dev.cfg.ModuleDefLoader$1.load(ModuleDefLoader.java:100)
        at com.google.gwt.dev.cfg.ModuleDefLoader.doLoadModule(ModuleDefLoader.java:197)
```

Haven't yet debugged too far, but the ModuleDefLoader and ReflectiveParser don't appear to have changed appreciable. What has changed is the version of xerces used in gwt-dev.jar:

```
-          <include name="xerces/xerces-2_9_1/serializer.jar" />
-          <include name="xerces/xerces-2_9_1/xercesImpl-NoMetaInf.jar" />
-          <include name="xerces/xerces-2_9_1/xml-apis.jar" />
+          <include name="xerces/xerces-2_11_0/serializer-2.7.1.jar" />
+          <include name="xerces/xerces-2_11_0/xercesImpl-2.11.0.jar" />
+          <include name="xerces/xerces-2_11_0/xml-apis-1.4.01.jar" />
```

This change was in https://gwt.googlesource.com/gwt/+/8c269b61 with review at https://gwt-review.googlesource.com/#/c/4323/. I'm not sure if we need classpath trickery to make this work, or if this is a version conflict of some sort - I don't see any existing classpath trickery this work though, nor do I see another version on the classpath (aside from the one in java itself, which has a different package, so seems unlikely to be involved.
