### PR TITLE
Handle maven projects without populated dependencies

### DIFF
--- a/src/main/java/net/ltgt/gwt/maven/CodeServerMojo.java
+++ b/src/main/java/net/ltgt/gwt/maven/CodeServerMojo.java
@@ -253,6 +253,10 @@ public class CodeServerMojo extends AbstractMojo {
   private void addSources(MavenProject p, LinkedHashSet<String> sources) {
     getLog().debug("Adding sources for " + p.getId());
     sources.addAll(p.getCompileSourceRoots());
+    if (p.getDependencyArtifacts() == null) {
+      getLog().debug("Ignoring dependencies for " + p.getId() + "; no dependency artifacts");
+      return;
+    }
     for (Artifact artifact : p.getDependencyArtifacts()) {
       if (!artifactFilter.include(artifact)) {
         continue;


### PR DESCRIPTION
The maven project dependencies are only populated in the maven
project model when the project is in the current reactor.

Don't throw a NullPointerException but ignore dependencies when
they aren't populated.