### PR TITLE
Add sources for gwt-lib packaged dependencies in reactor

### DIFF
--- a/src/main/java/net/ltgt/gwt/maven/CodeServerMojo.java
+++ b/src/main/java/net/ltgt/gwt/maven/CodeServerMojo.java
@@ -268,16 +268,17 @@ public class CodeServerMojo extends AbstractMojo {
       if (!artifactFilter.include(artifact)) {
         continue;
       }
-      if (!"java-source".equals(artifact.getArtifactHandler().getPackaging()) &&
-          !"gwt-lib".equals(artifact.getArtifactHandler().getPackaging()) &&
-          !"sources".equals(artifact.getClassifier())) {
-        getLog().debug("Ignoring " + artifact.getId() + "; neither a java-source, gwt-lib or jar:sources.");
-        continue;
-      }
       String key = ArtifactUtils.key(artifact);
       MavenProject reference = p.getProjectReferences().get(key);
       if (reference == null) {
         getLog().debug("Ignoring " + artifact.getId() + "; no corresponding project reference.");
+        continue;
+      }
+      if (!"java-source".equals(artifact.getArtifactHandler().getPackaging()) &&
+          !"gwt-lib".equals(artifact.getArtifactHandler().getPackaging()) &&
+          !"sources".equals(artifact.getClassifier()) &&
+          !"gwt-lib".equals(reference.getPackaging())) {
+        getLog().debug("Ignoring " + artifact.getId() + "; neither a java-source, gwt-lib or jar:sources.");
         continue;
       }
       addSources(reference, sources);


### PR DESCRIPTION
Maven projects which are packaged as gwt-lib produce a jar
artifact and aren't added as sources for the codeserver.

By adding the sources for gwt-lib packaged dependencies to
the codeserver there is no need to add a dependency on the
sources anymore.