### PR TITLE
Added self explanatory log info for each goal…

### DIFF
--- a/src/main/java/net/ltgt/gwt/maven/AddSuperSourceMojo.java
+++ b/src/main/java/net/ltgt/gwt/maven/AddSuperSourceMojo.java
@@ -44,6 +44,7 @@ public class AddSuperSourceMojo extends AbstractAddSuperSourcesMojo {
 
   @Override
   protected void addResource(Resource resource) {
+    getLog().info("Adding project.resource " + resource);
     project.addResource(resource);
   }
 

--- a/src/main/java/net/ltgt/gwt/maven/AddTestSuperSourcesMojo.java
+++ b/src/main/java/net/ltgt/gwt/maven/AddTestSuperSourcesMojo.java
@@ -44,6 +44,7 @@ public class AddTestSuperSourcesMojo extends AbstractAddSuperSourcesMojo {
 
   @Override
   protected void addResource(Resource resource) {
+    getLog().info("Adding project.testResource " + resource);
     project.addTestResource(resource);
   }
 

--- a/src/main/java/net/ltgt/gwt/maven/EnforceEncodingMojo.java
+++ b/src/main/java/net/ltgt/gwt/maven/EnforceEncodingMojo.java
@@ -24,6 +24,8 @@ public class EnforceEncodingMojo extends AbstractMojo {
       getLog().info("Setting project.build.sourceEncoding to UTF-8");
     } else if (!encoding.equalsIgnoreCase("UTF-8")) {
       getLog().warn("Encoding was set to " + encoding + "; forcing it to UTF-8");
+    } else {
+      getLog().info("Project already has UTF-8 encoding");
     }
     project.getProperties().setProperty("project.build.sourceEncoding", "UTF-8");
   }

--- a/src/main/java/net/ltgt/gwt/maven/GenerateModuleMetadataMojo.java
+++ b/src/main/java/net/ltgt/gwt/maven/GenerateModuleMetadataMojo.java
@@ -60,7 +60,7 @@ public class GenerateModuleMetadataMojo extends AbstractMojo {
       try {
         String content = FileUtils.fileRead(outputFile, "UTF-8");
         if (content.trim().equals(moduleName)) {
-          getLog().info(outputFile.getAbsolutePath() + " up to date - skipping.");
+          getLog().info("Skip up to date module metadata " + outputFile.getAbsolutePath());
           return;
         }
       } catch (IOException e) {
@@ -70,6 +70,7 @@ public class GenerateModuleMetadataMojo extends AbstractMojo {
 
     outputDirectory.mkdirs();
     try {
+      getLog().info("Writing module metadata " + outputFile.getAbsolutePath());
       FileUtils.fileWrite(outputFile, "UTF-8", moduleName);
     } catch (IOException e) {
       throw new MojoExecutionException(e.getMessage(), e);

--- a/src/main/java/net/ltgt/gwt/maven/GenerateModuleMojo.java
+++ b/src/main/java/net/ltgt/gwt/maven/GenerateModuleMojo.java
@@ -216,10 +216,11 @@ public class GenerateModuleMojo extends AbstractMojo {
 
     try {
       if (outputFile.isFile() && writer.toString().equals(FileUtils.fileRead(outputFile, "UTF-8"))) {
-        getLog().info(outputFile.getAbsolutePath() + " up to date - skipping");
+        getLog().info("Skip up to date module " + outputFile.getAbsolutePath());
         return;
       }
 
+      getLog().info("Writing module " + outputFile.getAbsolutePath());
       FileUtils.fileWrite(outputFile, "UTF-8", writer.toString());
       buildContext.refresh(outputFile);
     } catch (IOException e) {

--- a/src/main/java/net/ltgt/gwt/maven/ImportSourcesMojo.java
+++ b/src/main/java/net/ltgt/gwt/maven/ImportSourcesMojo.java
@@ -19,6 +19,7 @@ public class ImportSourcesMojo extends AbstractImportSourcesMojo {
 
   @Override
   protected void addResource(Resource resource) {
+    getLog().info("Adding project.resource " + resource);
     project.addResource(resource);
   }
 

--- a/src/main/java/net/ltgt/gwt/maven/ImportTestSourcesMojo.java
+++ b/src/main/java/net/ltgt/gwt/maven/ImportTestSourcesMojo.java
@@ -19,6 +19,7 @@ public class ImportTestSourcesMojo extends AbstractImportSourcesMojo {
 
   @Override
   protected void addResource(Resource resource) {
+    getLog().info("Adding project.testResource " + resource);
     project.addTestResource(resource);
   }
 


### PR DESCRIPTION
I created this pull request mainly to comment the idea. I think that add a good logging info messages is extremely useful. Maven is based on conventions/defaults and this frequently result in "magic" behaviours. So, adding this logging always indicating if something has been done or skipped (and maybe the cause) is extremely useful when you start using the plugin.

This output show the messages added for this various goals, so now is trivial to know whats the goal is doing.
```
INFO] --- gwt-maven-plugin:1.0-SNAPSHOT:enforce-encoding (default-enforce-encoding) @ e2e-model-gwt ---
[INFO] Project already has UTF-8 encoding
[INFO] 
[INFO] --- gwt-maven-plugin:1.0-SNAPSHOT:add-super-sources (default-add-super-sources) @ e2e-model-gwt ---
[INFO] Adding project.resource Resource {targetPath: null, filtering: false, FileSet {directory: src/main/super, PatternSet [includes: {**/*.java}, excludes: {}]}}
[INFO] 
[INFO] --- gwt-maven-plugin:1.0-SNAPSHOT:add-test-super-sources (default-add-test-super-sources) @ e2e-model-gwt ---
[INFO] Adding project.testResource Resource {targetPath: null, filtering: false, FileSet {directory: src/test/super, PatternSet [includes: {**/*.java}, excludes: {}]}}
[INFO] 
[INFO] --- gwt-maven-plugin:1.0-SNAPSHOT:import-sources (default-import-sources) @ e2e-model-gwt ---
[INFO] Adding project.resource Resource {targetPath: null, filtering: false, FileSet {directory: /Users/ibaca/Code/tbroyer.gwt-maven-plugin/target/it-tests/e2e/e2e-model-gwt/src/main/java, PatternSet [includes: {**/*.java}, excludes: {}]}}
[INFO] 
[INFO] --- gwt-maven-plugin:1.0-SNAPSHOT:generate-module (default-generate-module) @ e2e-model-gwt ---
[INFO] Skip up to date module /Users/ibaca/Code/tbroyer.gwt-maven-plugin/target/it-tests/e2e/e2e-model-gwt/target/classes/it/test/model/TestModel.gwt.xml
[INFO] 
[INFO] --- gwt-maven-plugin:1.0-SNAPSHOT:generate-module-metadata (default-generate-module-metadata) @ e2e-model-gwt ---
[INFO] Skip up to date module metadata /Users/ibaca/Code/tbroyer.gwt-maven-plugin/target/it-tests/e2e/e2e-model-gwt/target/classes/META-INF/gwt/mainModule
```

Your plugin has clear and simple code, but I think that add this logging will not add too much code. 

Ironically (bc it's not included), the goal that motivates this pull request was the test goal, which detect the *Suite.java clases but not the normal *Test.java classes. This differs from the mojo gwt plugin, and during migration this convention differences was a bit annoying because the test that works (was executed) previously now does not work. The examples has no configuration because you made this match your own conventions, so as I said, this conventions are some time seen as magic. BUT! the AbstractSurfirePlugin made a bit more complicated add this logging message. I do not investigate deeply. I'll try later. But something like "No test found matching {includedList..., exculdedList..., specificTests}" made the user absolute sure about what's happening.

The whole idea is simple, after every goal must be at least one info message saying what done or what's skipped, hopefully with the cause.