### PR TITLE
Allow using a module name without a package name.

### DIFF
--- a/src/main/java/net/ltgt/gwt/maven/AbstractAddSuperSourcesMojo.java
+++ b/src/main/java/net/ltgt/gwt/maven/AbstractAddSuperSourcesMojo.java
@@ -29,10 +29,15 @@ public abstract class AbstractAddSuperSourcesMojo extends AbstractSourcesAsResou
           throw new MojoExecutionException("Cannot relocate super-sources if moduleName is not specified");
         }
         String targetPath = moduleName.replace('.', '/');
-        // Keep only package name
-        targetPath = targetPath.substring(0, targetPath.lastIndexOf('/'));
+        // Keep only package name (if there is one)
+        int lastTrailingSlash = targetPath.lastIndexOf('/');
+        if (lastTrailingSlash > 0) {
+          targetPath = targetPath.substring(0, lastTrailingSlash + 1);
+        } else {
+          targetPath = "";	
+        }
         // Relocate into 'super' subfolder
-        targetPath = ensureTrailingSlash(targetPath) + "super/";
+        targetPath += "super/";
         resource.setTargetPath(targetPath);
       }
       addResource(resource);


### PR DESCRIPTION
Remove ensureTrailingSlash call as the slash is already there (it is actually used for splitting the path).
A module name without a package part results in a super directory created at the target/classes directory.

Fixes this error for a module named "gwt-util":
[ERROR] Failed to execute goal net.ltgt.gwt.maven:gwt-maven-plugin:1.0-rc-3:add-super-sources (add-super-sources) on project gwt-util: Execution add-super-sources of goal net.ltgt.gwt.maven:gwt-maven-plugin:1.0-rc-3:add-super-sources failed: String index out of range: -1 -> [Help 1]
