### PR TITLE
Adding compile commandline console output.

### DIFF
--- a/src/main/java/net/ltgt/gwt/maven/CompileMojo.java
+++ b/src/main/java/net/ltgt/gwt/maven/CompileMojo.java
@@ -204,6 +204,8 @@ public class CompileMojo extends AbstractMojo implements GwtOptions {
     commandline.addEnvironment("CLASSPATH", StringUtils.join(cp.iterator(), File.pathSeparator));
     commandline.addArguments(args.toArray(new String[args.size()]));
 
+    getLog().info("Executing: " + commandline.toString());
+    
     int result;
     try {
       result = CommandLineUtils.executeCommandLine(commandline,


### PR DESCRIPTION
I think adding the command line output would be nifty to always have handy. I'm trying to setup the plugin and having some issues, and wanted to check out the logging. I see the abstract mojo only turns it on during debugging.