### PR TITLE
Prevent spurious recompile if module name is dup'd

### DIFF
--- a/src/main/java/net/ltgt/gwt/maven/AbstractDevModeMojo.java
+++ b/src/main/java/net/ltgt/gwt/maven/AbstractDevModeMojo.java
@@ -140,7 +140,7 @@ public abstract class AbstractDevModeMojo extends AbstractMojo {
       throw new MojoExecutionException("No project found");
     }
 
-    List<String> moduleList = new ArrayList<>();
+    Set<String> moduleList = new LinkedHashSet<>();
     if (StringUtils.isBlank(modules)) {
       List<String> nonGwtProjects = new ArrayList<>();
       for (MavenProject p : projectList) {


### PR DESCRIPTION
From a conversation on gitter;
complete app showing issue is here:
https://github.com/avierax/temp1

I would be happy to add a test if you want, though I'd rather be working on gradle plugin to get something more exciting coming your way.