### PR TITLE
fix CTRL-C on Windows by replacing out-of-date plexus-utils command line stuff with ProcessBuilder->inheritIO()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 target/
+.settings/
+.classpath
+.project


### PR DESCRIPTION
CTRL-C now works properly on WIndows and Linux. I threw out the entire ancient plexus-utils command line handling für the Codeserver and replaced it with a quick and simple ProcessBuilder. It's not as colorful now and it doesn't get directed through a logger, but it also doesn't require a shutdown hook now (which wasn't working anyways on Windows).