### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,24 +144,9 @@
 
     <!-- Some artifacts used by invoker tests, declared here so they're resolved early -->
     <!-- Actually because invoker plugin cannot install snapshots through extraArtifacts -->
-    <dependency>
-      <groupId>com.google.gwt</groupId>
-      <artifactId>gwt-user</artifactId>
-      <version>${gwtVersion}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.gwt</groupId>
-      <artifactId>gwt-dev</artifactId>
-      <version>${gwtVersion}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.gwt</groupId>
-      <artifactId>gwt-servlet</artifactId>
-      <version>${gwtVersion}</version>
-      <scope>test</scope>
-    </dependency>
+    
+    
+    
   </dependencies>
 
   <build>


### PR DESCRIPTION

[Apache Maven Dependency Plugin](https://maven.apache.org/plugins/maven-dependency-plugin/index.html) can be used to find unused dependencies. And I found following list. Maybe we can remove them.
gwt-maven-plugin
{groupId='com.google.gwt', artifactId='gwt-user'}
{groupId='com.google.gwt', artifactId='gwt-dev'}
{groupId='com.google.gwt', artifactId='gwt-servlet'}


=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
